### PR TITLE
Detect crashes in make and create fatal error.

### DIFF
--- a/src/LaTeXML-Dockerfile
+++ b/src/LaTeXML-Dockerfile
@@ -35,7 +35,7 @@
 
 
 # We start from alpine linux 3.11
-FROM alpine:3.13 as latexml_base
+FROM alpine:3.12 as latexml_base
 
 RUN echo -e \
 " ############################################################\n" \

--- a/volume/build/config/configGeneral.php
+++ b/volume/build/config/configGeneral.php
@@ -10,16 +10,17 @@ define("DBG_EXEC", 4);
 define("DBG_ALARM", 8);
 define("DBG_SIGNAL", 16);
 define("DBG_CHILD", 32);
-define("DBG_DELETE", 64);
-define("DBG_PARSE_ERRLOG", 128);
-define("DBG_PARSE_POST", 256);
-define("DBG_HOSTS", 512);
+define("DBG_CHILD_RETVAL", 64);
+define("DBG_DELETE", 128);
+define("DBG_PARSE_ERRLOG", 256);
+define("DBG_PARSE_POST", 512);
+define("DBG_HOSTS", 1024);
 
 $dbgLevel = getenv('DBG_LEVEL');
 if ($dbgLevel !== false && $dbgLevel != '') {
-    define("DBG_LEVEL", (int)$dbgLevel);
+    define("DBG_LEVEL", (int) $dbgLevel);
 } else {
-    define("DBG_LEVEL", 4 | 128);
+    define("DBG_LEVEL", DBG_EXEC | DBG_PARSE_ERRLOG | DBG_CHILD_RETVAL);
 }
 
 // not supported yet

--- a/volume/build/config/configHosts.php
+++ b/volume/build/config/configHosts.php
@@ -16,11 +16,21 @@ use Dmake\UtilHost;
 use Dmake\UtilStage;
 /**
  * @var StdClass $config
+ * set -o pipefail: return status of failing program
  */
-define('MAKE_DEFAULT', $config->app->nice . ' -n 4 ' . $config->app->make . ' -f Makefile');
+define('MAKE_DEFAULT',
+       'set -o pipefail; '
+       . $config->app->nice . ' -n 4 '
+       . $config->app->make . ' -f Makefile');
+
+// __MAKELOG__ is replaced by $cfg->stages[$stage]->makeLog
+define('MAKE_OUTPUT', '2>&1 | tee __MAKELOG__');
+
 define(
     'MAKE_PDF',
-    $config->app->make . ' -f Makefile pdfclean; ' . $config->app->nice . ' -n 4 ' . $config->app->make . ' -f Makefile pdf'
+    'set -o pipefail; '
+    . $config->app->make . ' -f Makefile pdfclean; '
+    . $config->app->nice . ' -n 4 ' . $config->app->make . ' -f Makefile pdf'
 );
 
 /**
@@ -51,6 +61,7 @@ if ($dockerized) {
                     'status' => STAT_IDLE,
                     'dir' => ARTICLEDIR,
                     'make_default' => MAKE_DEFAULT,
+                    'make_output' => MAKE_OUTPUT,
                     'make_pdf' => MAKE_PDF,
                 ];
         }
@@ -67,6 +78,7 @@ if ($dockerized) {
                     'status' => STAT_IDLE,
                     'dir' => ARTICLEDIR,
                     'make_default' => MAKE_DEFAULT,
+                    'make_output' => MAKE_OUTPUT,
                     'make_pdf' => MAKE_PDF,
                 ],
             'local_1' =>
@@ -76,6 +88,7 @@ if ($dockerized) {
                     'status' => STAT_IDLE,
                     'dir' => ARTICLEDIR,
                     'make_default' => MAKE_DEFAULT,
+                    'make_output' => MAKE_OUTPUT,
                     'make_pdf' => MAKE_PDF,
                 ],
             'local_2' =>
@@ -85,6 +98,7 @@ if ($dockerized) {
                     'status' => STAT_IDLE,
                     'dir' => ARTICLEDIR,
                     'make_default' => MAKE_DEFAULT,
+                    'make_output' => MAKE_OUTPUT,
                     'make_pdf' => MAKE_PDF,
                     'make_xml' => MAKE_XML,
                     'make_xhtml' => MAKE_XHTML,
@@ -97,6 +111,7 @@ if ($dockerized) {
                     'status' => STAT_IDLE,
                     'dir' => ARTICLEDIR,
                     'make_default' => MAKE_DEFAULT,
+                    'make_output' => MAKE_OUTPUT,
                     'make_pdf' => MAKE_PDF,
                 ],
             'local_4' =>
@@ -106,6 +121,7 @@ if ($dockerized) {
                     'status' => STAT_IDLE,
                     'dir' => ARTICLEDIR,
                     'make_default' => MAKE_DEFAULT,
+                    'make_output' => MAKE_OUTPUT,
                     'make_pdf' => MAKE_PDF,
                 ],
             'local_5' =>
@@ -115,6 +131,7 @@ if ($dockerized) {
                     'status' => STAT_IDLE,
                     'dir' => ARTICLEDIR,
                     'make_default' => MAKE_DEFAULT,
+                    'make_output' => MAKE_OUTPUT,
                     'make_pdf' => MAKE_PDF,
                 ],
             'local_6' =>
@@ -124,6 +141,7 @@ if ($dockerized) {
                     'status' => STAT_IDLE,
                     'dir' => ARTICLEDIR,
                     'make_default' => MAKE_DEFAULT,
+                    'make_output' => MAKE_OUTPUT,
                     'make_pdf' => MAKE_PDF,
                 ],
             'local_7' =>
@@ -133,6 +151,7 @@ if ($dockerized) {
                     'status' => STAT_IDLE,
                     'dir' => ARTICLEDIR,
                     'make_default' => MAKE_DEFAULT,
+                    'make_output' => MAKE_OUTPUT,
                     'make_pdf' => MAKE_PDF,
                 ],
         );

--- a/volume/build/dmake/AbstractStage.php
+++ b/volume/build/dmake/AbstractStage.php
@@ -98,7 +98,19 @@ abstract class AbstractStage implements StageInterface
     abstract public static function parse(
         string $hostGroup,
         StatEntry $entry,
+        int $status,
         bool $childAlarmed
     ): bool;
+
+    public static function parseMakelog(
+        string $filename
+    ) : string {
+        $content = file_get_contents($filename);
+        if ($content === false) {
+            return '';
+        }
+        // for now just return the full log.
+        return $content;
+    }
 }
 

--- a/volume/build/dmake/StageInterface.php
+++ b/volume/build/dmake/StageInterface.php
@@ -21,6 +21,7 @@ interface StageInterface
 	public static function parse(
 	    string $hostGroup,
         StatEntry $entry,
+        int $status,
         bool $childAlarmed
     ): bool;
 }

--- a/volume/build/dmake/UtilStage.php
+++ b/volume/build/dmake/UtilStage.php
@@ -57,7 +57,7 @@ class UtilStage
         $json = file_get_contents(ACTIVESTAGESFILE);
         if ($json === false) {
             echo "Failed to load current active stages to " . ACTIVESTAGESFILE;
-            return false;
+            return [];
         }
         $activeStages = json_decode($json, true);
         return $activeStages;
@@ -99,8 +99,8 @@ class UtilStage
     public static function setupFiles(
         string $articleDir,
         string $directory,
-        string $hostGroupName): void
-    {
+        string $hostGroupName
+    ): void {
         $sourceDir = $articleDir . '/' . $directory;
         $destDir = $articleDir . '/' . $directory . '/__texmlbus_' . $hostGroupName;
         if (!file_exists($destDir)) {
@@ -113,8 +113,8 @@ class UtilStage
     public static function getSourceDir(
         string $articleDir,
         string $directory,
-        string $hostGroup): string
-    {
+        string $hostGroup
+    ): string {
         $cfg = Config::getConfig();
 
         if ($cfg->linkSourceFiles) {
@@ -123,5 +123,27 @@ class UtilStage
             $sourceDir = $articleDir . '/' . $directory;
         }
         return $sourceDir;
+    }
+
+    /**
+     * Determine the makeCommand
+     * @return string
+     */
+    public static function getMakeCommand(
+        array $host,
+        string $action,
+        string $makeLog
+    ) : string {
+        $makeAction = 'make_' . $action;
+
+        // if there is a defined command like MAKE_PDF, use that otherwise just "make action"
+        if (isset($host[$makeAction])) {
+            $makeCommand = $host[$makeAction];
+        } else {
+            $makeCommand = $host['make_default'] . ' ' . $action;
+        }
+        $makeCommand .= ' ' . str_replace('__MAKELOG__', $makeLog, $host['make_output']);
+
+        return $makeCommand;
     }
 }

--- a/volume/build/stage/pdf_edge/StagePdfEdge.php
+++ b/volume/build/stage/pdf_edge/StagePdfEdge.php
@@ -13,13 +13,14 @@ class StagePdfEdge extends StagePdf
 {
     public static function register(): array
     {
+        $stage = 'pdf_edge';
         $config = [
-            'stage' => 'pdf_edge',
+            'stage' => $stage,
             'classname' => __CLASS__,
-            'target' => 'pdf',
+            'target' => 'pdf', // pdf is correct
             'hostGroup' => 'worker_edge',
-            'dbTable' => 'retval_pdf_edge',
-            'tableTitle' => 'pdf_edge',
+            'dbTable' => 'retval_' . $stage,
+            'tableTitle' => $stage,
             'toolTip' => 'PDF creation.',
             'parseXml' => false,
             'timeout' => 240,
@@ -27,6 +28,7 @@ class StagePdfEdge extends StagePdf
             'destFile' => '%MAINFILEPREFIX%.pdf',
             'stdoutLog' => '%MAINFILEPREFIX%.log', // this needs to match entry in Makefile
             'stderrLog' => '%MAINFILEPREFIX%.log', // needs to match entry in Makefile
+            'makeLog' => 'make_' . $stage . '.log',
             'dependentStages' => [], // which log files need to be parsed?
             'showRetval' => [
                 'unknown' => true,

--- a/volume/build/stage/xhtml/StageXhtml.php
+++ b/volume/build/stage/xhtml/StageXhtml.php
@@ -23,18 +23,20 @@ class StageXhtml extends AbstractStage
 
     public static function register(): array
     {
+        $stage = 'xhtml';
         $config = [
-            'stage' => 'xhtml',
+            'stage' => $stage,
             'classname' => __CLASS__,
-            'target' => 'xhtml',
+            'target' => $stage,
             'hostGroup' => 'worker',
-            'dbTable' => 'retval_xhtml',
-            'tableTitle' => 'xhtml',
+            'dbTable' => 'retval_' . $stage,
+            'tableTitle' => $stage,
             'toolTip' => 'Xhtml creation.',
             'timeout' => 1200,
             'destFile' => '%MAINFILEPREFIX%.xhtml',
-            'stdoutLog' => 'xhtml.stdout.log',  // this needs to match entry in Makefile
-            'stderrLog' => 'xhtml.stderr.log',  // needs to match entry in Makefile
+            'stdoutLog' => $stage . '.stdout.log',  // this needs to match entry in Makefile
+            'stderrLog' => $stage . '.stderr.log',  // needs to match entry in Makefile
+            'makeLog' => 'make_' . $stage . '.log',
             // which log files need to be parsed?
             // the dependent stage needs to have the same hostGroup as this stage
             'dependentStages' => ['xml'],
@@ -189,6 +191,7 @@ class StageXhtml extends AbstractStage
     public static function parse(
         string $hostGroup,
         StatEntry $entry,
+        int $status,
         bool $childAlarmed): bool
     {
         $directory = $entry->filename;
@@ -199,6 +202,7 @@ class StageXhtml extends AbstractStage
         $sourceDir = UtilStage::getSourceDir(ARTICLEDIR, $directory, $hostGroup);
         $texSourcefile = $sourceDir . '/' . $entry->getSourcefile();
         $stderrlog = $sourceDir . '/' . $res->config['stderrLog'];
+        $makelog = $sourceDir . '/' . $res->config['makeLog'];
 
         if ($childAlarmed) {
             $res->retval = 'timeout';
@@ -206,129 +210,130 @@ class StageXhtml extends AbstractStage
         } elseif (!UtilFile::isFileTexfile($texSourcefile)) {
             $res->retval = 'not_qualified';
         } elseif (!is_file($stderrlog)) {
-            $res->retval = 'missing_errlog';
-        } else {
-            // have we created an xhtml file?
-/*
-
-            $arr = glob(ARTICLEDIR.'/'.$directory.'/*.xhtml');
-            if (count($arr)) {
-                $res->retval = 'no_problems';
-                $last = strrpos($arr[0], '/');
+            if ($status) {
+                $res->retval = 'fatal_error';
+                $res->errmsg = static::parseMakelog($makelog);
             } else {
-                $res->retval = 'fatal_error';
+                $res->retval = 'missing_errlog';
             }
-*/
+        } else {
             $content = file_get_contents($stderrlog);
-
-            // matches[3] ==> num_xmarg
-            // matches[4] ==> ok_xmarg
-            $xmarg_pattern = '@(.*?)(^   XMArg: )(\d+)/(\d+)@m';
-            $matches = [];
-            preg_match($xmarg_pattern, $content, $matches);
-            if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
-                print_r($matches);
-            }
-
-            if (isset($matches[3])) {
-                $res->num_xmarg = $matches[3];
-            }
-            if (isset($matches[4])) {
-                $res->ok_xmarg = $matches[4];
-            }
-
-            // matches[3] ==> num_xmath
-            // matches[4] ==> ok_xmath
-            $xmath_pattern = '@(.*?)(^   XMath: )(\d+)/(\d+)@m';
-            preg_match($xmath_pattern, $content, $matches);
-
-            if (isset($matches[3])) {
-                $res->num_xmath = $matches[3];
-            }
-            if (isset($matches[4])) {
-                $res->ok_xmath = $matches[4];
-            }
-
-
-            $fatal_pattern = '@(.*?)(^Fatal:)(\S*)\s+(.*)@m';
-            preg_match($fatal_pattern, $content, $matches);
-            if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
-                print_r($matches);
-            }
-
-            // this will only be set if we have found a fatal error
-            if (isset($matches[2])) {
+            if ($status
+                && ($content === ''
+                    || strpos($content, 'processing finished') === false)
+            ) {
                 $res->retval = 'fatal_error';
-                $res->errmsg = $matches[4];
-            }
-            /*
-
-            $warning_pattern = '@(.*?)(^Conversion complete: )((\d*)(\s*)((warning|error)?)(s?)(; ?)?)((\d*)(\s*)(error?)?)@m';
-            preg_match($warning_pattern, $content, $matches);
-            print_r($matches);
-
-            if (isset($matches[6])) {
-                $res->retval = 'warning';
-                if ($matches[6] == 'error') {
-                    $res->num_error = $matches[4];
-                } elseif ($matches[6]  == 'warning') {
-                    $res->num_warning = $matches[4];
-                    if (isset($matches[13])) {
-                        $res->num_error = $matches[11];
-                    }
-                } else {
-                    echo "Error, neither warning nor error...\n";
+                $res->errmsg = static::parseMakelog($makelog);
+            } else {
+                // matches[3] ==> num_xmarg
+                // matches[4] ==> ok_xmarg
+                $xmarg_pattern = '@(.*?)(^   XMArg: )(\d+)/(\d+)@m';
+                $matches = [];
+                preg_match($xmarg_pattern, $content, $matches);
+                if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                    print_r($matches);
                 }
-            }
-            */
 
-            $warning_pattern = '@(.*?)(^Postprocessing complete: )(.*?)(\d*)(\s*)(warning)@m';
-            preg_match($warning_pattern, $content, $matches);
-            if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                if (isset($matches[3])) {
+                    $res->num_xmarg = $matches[3];
+                }
+                if (isset($matches[4])) {
+                    $res->ok_xmarg = $matches[4];
+                }
+
+                // matches[3] ==> num_xmath
+                // matches[4] ==> ok_xmath
+                $xmath_pattern = '@(.*?)(^   XMath: )(\d+)/(\d+)@m';
+                preg_match($xmath_pattern, $content, $matches);
+
+                if (isset($matches[3])) {
+                    $res->num_xmath = $matches[3];
+                }
+                if (isset($matches[4])) {
+                    $res->ok_xmath = $matches[4];
+                }
+
+
+                $fatal_pattern = '@(.*?)(^Fatal:)(\S*)\s+(.*)@m';
+                preg_match($fatal_pattern, $content, $matches);
+                if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                    print_r($matches);
+                }
+
+                // this will only be set if we have found a fatal error
+                if (isset($matches[2])) {
+                    $res->retval = 'fatal_error';
+                    $res->errmsg = $matches[4];
+                }
+                /*
+
+                $warning_pattern = '@(.*?)(^Conversion complete: )((\d*)(\s*)((warning|error)?)(s?)(; ?)?)((\d*)(\s*)(error?)?)@m';
+                preg_match($warning_pattern, $content, $matches);
                 print_r($matches);
-            }
 
-            if (isset($matches[6]) && $matches[6] == 'warning') {
-                $res->num_warning = $matches[4];
-                $res->retval = 'warning';
-            }
+                if (isset($matches[6])) {
+                    $res->retval = 'warning';
+                    if ($matches[6] == 'error') {
+                        $res->num_error = $matches[4];
+                    } elseif ($matches[6]  == 'warning') {
+                        $res->num_warning = $matches[4];
+                        if (isset($matches[13])) {
+                            $res->num_error = $matches[11];
+                        }
+                    } else {
+                        echo "Error, neither warning nor error...\n";
+                    }
+                }
+                */
 
-            $error_pattern = '@(.*?)(^Postprocessing complete: )(.*?)(\d*)(\s*)(error)@m';
-            preg_match($error_pattern, $content, $matches);
-            if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
-                print_r($matches);
-            }
+                $warning_pattern = '@(.*?)(^Postprocessing complete: )(.*?)(\d*)(\s*)(warning)@m';
+                preg_match($warning_pattern, $content, $matches);
+                if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                    print_r($matches);
+                }
 
-            if (isset($matches[6]) && $matches[6] == 'error') {
-                $res->num_error = (int) $matches[4];
-                if ($res->num_error > 0) {
-                    $res->retval = 'error';
-                } else {
+                if (isset($matches[6]) && $matches[6] == 'warning') {
+                    $res->num_warning = $matches[4];
+                    $res->retval = 'warning';
+                }
+
+                $error_pattern = '@(.*?)(^Postprocessing complete: )(.*?)(\d*)(\s*)(error)@m';
+                preg_match($error_pattern, $content, $matches);
+                if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                    print_r($matches);
+                }
+
+                if (isset($matches[6]) && $matches[6] == 'error') {
+                    $res->num_error = (int)$matches[4];
+                    if ($res->num_error > 0) {
+                        $res->retval = 'error';
+                    } else {
+                        $res->retval = 'no_problems';
+                    }
+                }
+
+                $macro_pattern = '@(.*?)(^Postprocessing complete: )(.*?)(\d*)(\s*)(undefined macro)(s?)(.*)@m';
+                preg_match($macro_pattern, $content, $matches);
+                if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                    print_r($matches);
+                }
+
+                if (isset($matches[6]) && $matches[6] == 'undefined macro') {
+                    $res->num_macro = $matches[4];
+                    $res->missing_macros = $matches[8];
+                    $res->retval = 'missing_macros';
+                }
+
+                $success_pattern = '@(.*?)(^Postprocessing complete: No obvious problems)@m';
+                preg_match($success_pattern, $content, $matches);
+                if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                    print_r($matches);
+                }
+
+                // this will only be set if
+                if (isset($matches[2])) {
                     $res->retval = 'no_problems';
                 }
-            }
-
-            $macro_pattern = '@(.*?)(^Postprocessing complete: )(.*?)(\d*)(\s*)(undefined macro)(s?)(.*)@m';
-            preg_match($macro_pattern, $content, $matches);
-            if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
-                print_r($matches);
-            }
-
-            if (isset($matches[6]) && $matches[6] == 'undefined macro') {
-                $res->num_macro = $matches[4];
-                $res->missing_macros = $matches[8];
-                $res->retval = 'missing_macros';
-            }
-
-            $success_pattern = '@(.*?)(^Postprocessing complete: No obvious problems)@m';
-            preg_match($success_pattern, $content, $matches);
-            if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
-                print_r($matches);
-            }
-
-            // this will only be set if
-            if (isset($matches[2])) {
-                $res->retval = 'no_problems';
             }
         }
         return $res->updateRetval();

--- a/volume/build/stage/xml/StageXml.php
+++ b/volume/build/stage/xml/StageXml.php
@@ -28,19 +28,21 @@ class StageXml extends AbstractStage
 
     public static function register(): array
     {
+        $stage = 'xml';
         $config = [
-            'stage' => 'xml',
+            'stage' => $stage,
             'classname' => __CLASS__,
-            'target' => 'xml',
+            'target' => $stage,
             'hostGroup' => 'worker',
-            'dbTable' => 'retval_xml',
-            'tableTitle' => 'xml',
+            'dbTable' => 'retval_' . $stage,
+            'tableTitle' => $stage,
             'toolTip' => 'Latexml XML intermediate format creation.',
             'parseXml' => true,
             'timeout' => 1200,
             'destFile' => '%MAINFILEPREFIX%.tex.xml',
             'stdoutLog' => 'stdout.log', // this needs to match entry in Makefile
             'stderrLog' => 'stderr.log', // needs to match entry in Makefile
+            'makeLog' => 'make_' . $stage . '.log',
             'dependentStages' => [],
             'showRetval' => [
                 'unknown' => true,
@@ -287,6 +289,7 @@ class StageXml extends AbstractStage
     public static function parse(
         string $hostGroup,
         StatEntry $entry,
+        int $status,
         bool $childAlarmed): bool
     {
         $directory = $entry->filename;
@@ -295,9 +298,9 @@ class StageXml extends AbstractStage
         $res->id = $entry->id;
 
         $sourceDir = UtilStage::getSourceDir(ARTICLEDIR, $directory, $hostGroup);
-        $stderrlog = $sourceDir . '/' . $res->config['stderrLog'];
-
         $texSourcefile = $sourceDir . '/' . $entry->getSourcefile();
+        $stderrlog = $sourceDir . '/' . $res->config['stderrLog'];
+        $makelog = $sourceDir . '/' . $res->config['makeLog'];
 
         if ($childAlarmed) {
             $res->retval = 'timeout';
@@ -305,96 +308,108 @@ class StageXml extends AbstractStage
         } elseif (!UtilFile::isFileTexfile($texSourcefile)) {
             $res->retval = 'not_qualified';
         } elseif (!is_file($stderrlog)) {
-            $res->retval = 'missing_errlog';
+            if ($status) {
+                $res->retval = 'fatal_error';
+                $res->errmsg = static::parseMakelog($makelog);
+            } else {
+                $res->retval = 'missing_errlog';
+            }
         } else {
             $content = file_get_contents($stderrlog);
-
-            // matches[3] ==> num_xmarg
-            // matches[4] ==> ok_xmarg
-            $xmarg_pattern = '@(.*?)(^   XMArg: )(\d+)/(\d+)@m';
-            $matches = [];
-            preg_match($xmarg_pattern, $content, $matches);
-            if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
-                print_r($matches);
-            }
-
-            if (isset($matches[3])) {
-                $res->num_xmarg = $matches[3];
-            }
-            if (isset($matches[4])) {
-                $res->ok_xmarg = $matches[4];
-            }
-
-            // matches[3] ==> num_xmath
-            // matches[4] ==> ok_xmath
-            $xmath_pattern = '@(.*?)(^   XMath: )(\d+)/(\d+)@m';
-            preg_match($xmath_pattern, $content, $matches);
-
-            if (isset($matches[3])) {
-                $res->num_xmath = $matches[3];
-            }
-            if (isset($matches[4])) {
-                $res->ok_xmath = $matches[4];
-            }
-
-            $fatal_pattern = '@(.*?)(^Fatal:)(\S*)\s+(.*)@m';
-            preg_match($fatal_pattern, $content, $matches);
-            if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
-                print_r($matches);
-            }
-
-            // this will only be set if we have found a fatal error
-            if (isset($matches[2])) {
-                 $res->retval = 'fatal_error';
-                 $res->errmsg = $matches[4];
+            if ($content === ''
+                && $status
+            ) {
+                $res->retval = 'fatal_error';
+                $res->errmsg = static::parseMakelog($makelog);
             } else {
-                $warning_pattern = '@(.*?)(^Conversion complete: )(.*?)(\d*)(\s*)(warning)@m';
-                preg_match($warning_pattern, $content, $matches);
+
+                // matches[3] ==> num_xmarg
+                // matches[4] ==> ok_xmarg
+                $xmarg_pattern = '@(.*?)(^   XMArg: )(\d+)/(\d+)@m';
+                $matches = [];
+                preg_match($xmarg_pattern, $content, $matches);
                 if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
                     print_r($matches);
                 }
 
-                if (isset($matches[6]) && $matches[6] == 'warning') {
-                    $res->num_warning = $matches[4];
-                    $res->retval = 'warning';
+                if (isset($matches[3])) {
+                    $res->num_xmarg = $matches[3];
+                }
+                if (isset($matches[4])) {
+                    $res->ok_xmarg = $matches[4];
                 }
 
-                $error_pattern = '@(.*?)(^Conversion complete: )(.*?)(\d*)(\s*)(error)@m';
-                preg_match($error_pattern, $content, $matches);
+                // matches[3] ==> num_xmath
+                // matches[4] ==> ok_xmath
+                $xmath_pattern = '@(.*?)(^   XMath: )(\d+)/(\d+)@m';
+                preg_match($xmath_pattern, $content, $matches);
+
+                if (isset($matches[3])) {
+                    $res->num_xmath = $matches[3];
+                }
+                if (isset($matches[4])) {
+                    $res->ok_xmath = $matches[4];
+                }
+
+                $fatal_pattern = '@(.*?)(^Fatal:)(\S*)\s+(.*)@m';
+                preg_match($fatal_pattern, $content, $matches);
                 if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
                     print_r($matches);
                 }
 
-                if (isset($matches[6]) && $matches[6] == 'error') {
-                    $res->num_error = (int)$matches[4];
-                    if ($res->num_error > 0) {
-                        $res->retval = 'error';
-                    } else {
+                // this will only be set if we have found a fatal error
+                if (isset($matches[2])) {
+                     $res->retval = 'fatal_error';
+                     $res->errmsg = $matches[4];
+                } else {
+                    $warning_pattern = '@(.*?)(^Conversion complete: )(.*?)(\d*)(\s*)(warning)@m';
+                    preg_match($warning_pattern, $content, $matches);
+                    if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                        print_r($matches);
+                    }
+
+                    if (isset($matches[6]) && $matches[6] == 'warning') {
+                        $res->num_warning = $matches[4];
+                        $res->retval = 'warning';
+                    }
+
+                    $error_pattern = '@(.*?)(^Conversion complete: )(.*?)(\d*)(\s*)(error)@m';
+                    preg_match($error_pattern, $content, $matches);
+                    if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                        print_r($matches);
+                    }
+
+                    if (isset($matches[6]) && $matches[6] == 'error') {
+                        $res->num_error = (int)$matches[4];
+                        if ($res->num_error > 0) {
+                            $res->retval = 'error';
+                        } else {
+                            $res->retval = 'no_problems';
+                        }
+                    }
+
+                    $macro_pattern = '@(.*?)(^Conversion complete: )(.*?)(\d*)(\s*)(undefined macro)(s?)(.*)@m';
+                    preg_match($macro_pattern, $content, $matches);
+                    if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                        print_r($matches);
+                    }
+
+                    if (isset($matches[6]) && $matches[6] == 'undefined macro') {
+                        $res->num_macro = $matches[4];
+                        $res->missing_macros = $matches[8];
+                        $res->retval = 'missing_macros';
+                    }
+
+                    $success_pattern = '@(.*?)(^Conversion complete: No obvious problems)@m';
+                    preg_match($success_pattern, $content, $matches);
+                    if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
+                        print_r($matches);
+                    }
+
+                    // this will only be set if
+                    if (isset($matches[2])) {
                         $res->retval = 'no_problems';
                     }
-                }
-
-                $macro_pattern = '@(.*?)(^Conversion complete: )(.*?)(\d*)(\s*)(undefined macro)(s?)(.*)@m';
-                preg_match($macro_pattern, $content, $matches);
-                if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
-                    print_r($matches);
-                }
-
-                if (isset($matches[6]) && $matches[6] == 'undefined macro') {
-                    $res->num_macro = $matches[4];
-                    $res->missing_macros = $matches[8];
-                    $res->retval = 'missing_macros';
-                }
-
-                $success_pattern = '@(.*?)(^Conversion complete: No obvious problems)@m';
-                preg_match($success_pattern, $content, $matches);
-                if (DBG_LEVEL & DBG_PARSE_ERRLOG) {
-                    print_r($matches);
-                }
-
-                // this will only be set if
-                if (isset($matches[2])) {
-                    $res->retval = 'no_problems';
                 }
             }
         }


### PR DESCRIPTION
- latexmlpost with alpine 3.13 crashes with some testfiles (structure_itemize) in libxml.
- detect the error and create a fatal error status in this case
- go back to alpine 3.12 for latexml.