### PR TITLE
Correct sharing of latexml source code.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
         volumes:
             - ./volume/articles:/srv/texmlbus/articles
             - ./volume/build:/srv/texmlbus/build
-            - optdata:/opt
+            - optrun:/opt/run
 
     texmlbus:
         build:
@@ -108,14 +108,15 @@ services:
             - ./volume/articles:/srv/texmlbus/articles
             - ./volume/build:/srv/texmlbus/build
             # have access to latexmls style files
-            - optdata:/opt
+            - ./src/LaTeXML:/opt/latexml
+            - optrun:/opt/run
         command: '/bin/bash'
 
 networks:
     texmlbus_net:
 volumes:
     # shared by latexml-dmake and texmlbus
-    optdata:
+    optrun:
     # mysql database
     data-mysql:
 


### PR DESCRIPTION
- the webserver needs access to latexml test cases, but the way sharing has been
 setup was not correct, as the content in optdata was tried to be created at image creation.

- therefore dmake mounts the LaTeXML source directly
- only /opt/run is shared among the containers as content is written at runtime.