### PR TITLE
latexml test complex/tcilatex_minimal needs tcilatex

### DIFF
--- a/volume/build/dmake/AbstractClsLoader.php
+++ b/volume/build/dmake/AbstractClsLoader.php
@@ -146,7 +146,7 @@ abstract class AbstractClsLoader
     public function __construct()
     {
     }
-    
+
     /**
      * installs the cls/sty files
      * @return bool
@@ -166,10 +166,9 @@ abstract class AbstractClsLoader
     }
 
     /**
-     * installs the cls/sty files
-     * @return bool
+     * Installs the cls/sty files
      */
-    public function install(): bool
+    public function install(): string
     {
         $this->localFilename = $this->download($this->url);
         if (!$this->localFilename) {
@@ -189,16 +188,28 @@ abstract class AbstractClsLoader
         // remove tmpDir of downloaded file
         UtilFile::deleteDirR(dirname($this->localFilename));
 
-        $publisherDir = ARTICLESTYDIR . '/' . $this->getPublisher();
+        $publisherDir = ARTICLESTYDIR
+            . '/'
+            . UtilFile::sanitizeFilename($this->getPublisher());
         UtilFile::ensureDirExists($publisherDir);
         $destDir = $publisherDir . '/' . $this->getName();
         UtilFile::deleteDirR($destDir);
         UtilFile::rename($tmpDestDir, $destDir);
-        $this->installedFiles = UtilStylefile::getInstalledClsStyFiles($destDir);
 
         // remove tmpDir of extracted files / file.
         UtilFile::deleteDirR($tmpDestDir);
-        return true;
+        return $destDir;
+    }
+
+    /**
+     * Checks for existence of the to be installed files.
+     */
+    public function checkInstallation(string $destDir): bool
+    {
+        $this->installedFiles = UtilStylefile::getInstalledClsStyFiles(
+            $destDir,
+            $this->getFiles()
+        );
+        return count($this->installedFiles) > 0;
     }
 }
-

--- a/volume/build/dmake/UtilStylefile.php
+++ b/volume/build/dmake/UtilStylefile.php
@@ -291,9 +291,19 @@ class UtilStylefile
     /**
      * Returns the installed cls/sty files as
      * [name => path] Array.
+     * If checkfiles is empty, it checks for any .cls/.sty files,
+     * otherwise it checks for specific filenames.
      */
-    public static function getInstalledClsStyFiles($directory): array
+    public static function getInstalledClsStyFiles(
+        string $directory,
+        array $checkFiles = []): array
     {
+        if (empty($checkFiles)) {
+            $pattern = '/\.cls|\.sty|\.tex/';
+        } else {
+            $pattern = null;
+        }
+
         $currentDepth = -5;
         $result_dirs = [];
         UtilFile::listDirR(
@@ -302,12 +312,17 @@ class UtilStylefile
             $currentDepth,
             true,
             false,
-            '/\.cls|\.sty/',
+            $pattern,
         );
 
         $installedFiles = [];
         foreach ($result_dirs as $filename) {
-            $installedFiles[basename($filename)] = $filename;
+            $basename = basename($filename);
+            if (empty($checkFiles)
+                || in_array($basename, $checkFiles)
+            ) {
+                $installedFiles[basename($filename)] = $filename;
+            }
         }
         return $installedFiles;
     }

--- a/volume/build/dmake/clsloader/AAClsLoader.php
+++ b/volume/build/dmake/clsloader/AAClsLoader.php
@@ -20,7 +20,7 @@ class AaClsLoader extends AbstractClsLoader
         $this->setName('aa');
         $this->setPublisher('EDP Sciences');
         $this->setUrl('http://ftp.edpsciences.org/pub/aa/aa-package.zip');
-        $this->setFiles(['aa.cls']);
+        $this->setFiles(['aastex.cls']);
         $this->setComment('Astronomy & Astrophysics');
     }
 }

--- a/volume/build/dmake/clsloader/AastexClsLoader.php
+++ b/volume/build/dmake/clsloader/AastexClsLoader.php
@@ -24,15 +24,13 @@ class AastexClsLoader extends AbstractClsLoader
         $this->setComment('AAS Journals');
     }
 
-    public function install() : bool
+    public function install() : string
     {
-        parent::install();
-        $destDir = ARTICLESTYDIR . '/'
-            . $this->getPublisher() . '/'
-            . 'aastex/aastex';
-        $execStr = "cd $destDir && cp aastex??.cls aastex.cls";
+        $destDir = parent::install();
+        $execDir = $destDir . '/aastex';
+        $execStr = "cd $execDir && cp aastex??.cls aastex.cls";
         system($execStr);
-        return true;
+        return $destDir;
     }
 
 }

--- a/volume/build/dmake/clsloader/ElsearticleClsLoader.php
+++ b/volume/build/dmake/clsloader/ElsearticleClsLoader.php
@@ -25,16 +25,13 @@ class ElsearticleClsLoader extends AbstractClsLoader
         $this->setComment('Elsevier journals');
     }
 
-    public function install() : bool
+    public function install() : string
     {
-        parent::install();
-        $destDir = ARTICLESTYDIR . '/'
-            . $this->getPublisher() . '/'
-            . 'elsarticle/elsarticle';
-        $execStr = 'cd ' . $destDir .' && /usr/bin/pdftex elsarticle.ins';
+        $destDir = parent::install();
+        $execDir = $destDir . '/elsarticle';
+        $execStr = 'cd ' . $execDir .' && /usr/bin/pdftex elsarticle.ins';
         $result = UtilHost::runOnWorker('worker', $execStr);
-        // error_log($result);
-        return true;
+        return $destDir;
     }
 }
 

--- a/volume/build/dmake/clsloader/TcilatexClsLoader.php
+++ b/volume/build/dmake/clsloader/TcilatexClsLoader.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * MIT License
+ * (c) 2007 - 2019 Heinrich Stamerjohanns
+ *
+ */
+
+namespace Dmake\Clsloader;
+
+use Dmake\AbstractClsLoader;
+use Dmake\UtilFile;
+use Dmake\UtilStylefile;
+use Dmake\UtilZipfile;
+
+class TcilatexClsLoader extends AbstractClsLoader
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->setName('tcilatex');
+        $this->setPublisher('TCI Software Research, Inc');
+        $this->setUrl('ftp://ftp.mackichan.com/swandswp30/updates/tcitex/tex/latex/tci/tcilatex.tex');
+        $this->setFiles(['tcilatex.tex']);
+        $this->setComment('tcilatex.tex needed for latexml test');
+    }
+}
+

--- a/volume/build/server/htdocs/ajax/installSty.php
+++ b/volume/build/server/htdocs/ajax/installSty.php
@@ -30,7 +30,8 @@ if (!empty($className)) {
         $nsClassName = "Dmake\\ClsLoader\\" . $className;
         $obj = new $nsClassName;
         try {
-            $success = $obj->install();
+            $destDir = $obj->install();
+            $success = $obj->checkInstallation($destDir);
             if ($success) {
                 $out['message'] = 'Files installed.';
             } else {

--- a/volume/build/server/htdocs/js/installSty.js
+++ b/volume/build/server/htdocs/js/installSty.js
@@ -32,6 +32,9 @@ function installSty(element, name)
                     fadeMsec = 1000;
                 } else {
                     message += "No files have been installed.";
+                    $(element).removeClass();
+                    $(element).addClass('btn btn-primary');
+                    $(element).html('<i class="fas fa-cloud-download-alt"></i><span></span>');
                     msgClass = 'info';
                 }
                 showMessage('Sty Files Install', message, msgClass, 2500);


### PR DESCRIPTION
- the test needs tcilatex, so provider a loader.
- installation and check needs to be seperated, so install can be more easily overloaded
- show download cloud again if installation fails.