### PR TITLE
Make latexml --VERSION work correctly in dockerized environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,11 @@
-build/server/htdocs/info.php
+docker/LaTeXML_edge/
 volume/articles/
 !volume/articles/upload
 !volume/articles/upload/tmp
-volume/build/doc/manual.pdf
-volume/build/run/activestages.json
-volume/build/vendor
+volume/src/doc/manual.pdf
+volume/src/run/activestages.json
+volume/src/server/htdocs/info.php
+volume/src/vendor
 volume/db/mysql/
 *.swp
 *.kate-swp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,8 @@ services:
                     - dbserver
 
         # Uncomment, if you want to access db via local connection (e.g. IDE)
-        # you might need to explicitly set 127.0.0.1 in your configuration 
-        # and not localhost there. Please also note the different port 3307 to 
+        # you might need to explicitly set 127.0.0.1 in your configuration
+        # and not localhost there. Please also note the different port 3307 to
         # not interfere with a local database installation.
         #ports:
             # - "127.0.0.1:${TEXMLBUS_MYSQL:-3307}:3306"
@@ -28,17 +28,52 @@ services:
             - data-mysql:/var/lib/mysql
 
         # work around innodb problem under windows
-        command: 'mysqld --innodb-flush-method=fsync'
+        # uses its own volume, should be ok, now.
+        # command: 'mysqld --innodb-flush-method=fsync'
+
+    latexml_base:
+        build:
+            # needs access to LaTeXML as well
+            context: docker
+            dockerfile: latexml_base/Dockerfile
+            target: latexml_base
+            args:
+                # Sometimes a job (e.g. latexml) may run endlessly, limit
+                # the amount of time a job can run.
+                TIMEOUT_SECONDS: 1200
+
+        # actually just image is needed, not the container
+        # will soon use profile: never
+        command: 'echo "Ok, that this container exits."'
+
+    latexml_git:
+        build:
+            # needs access to modules
+            context: .
+            dockerfile: docker/latexml_git/Dockerfile
+            target: latexml_git
+        depends_on:
+            - latexml_base
+
+        # actually just image is needed, not the container
+        # will soon use profile: never
+        command: 'echo "OK, that this container exits."'
+        volumes:
+            - ./.git/modules/src/LaTeXML:/.git
 
     latexml:
         build:
             context: docker/LaTeXML
             dockerfile: ../LaTeXML-Dockerfile
             #dockerfile: release/docker/Dockerfile
-            target: latexml_base
+            target: latexml
             args:
-                - WITH_TEXLIVE=yes
                 - WITH_TESTS=no
+        depends_on:
+            - latexml_git
+
+        # actually just image is needed, not the container
+        # will soon use profile: never
         command: 'echo "OK, that this container exits."'
 
     latexml_dmake:
@@ -46,10 +81,8 @@ services:
             context: docker/latexml_dmake
             dockerfile: Dockerfile
             target: latexml_dmake
-            args:
-                # Sometimes a job (e.g. latexml) may run endlessly, limit
-                # the amount of time a job can run.
-                TIMEOUT_SECONDS: 1200
+        depends_on:
+            - latexml
 
         environment:
             DOCKERIZED: 1
@@ -85,17 +118,17 @@ services:
             # the amount of time a job can run.
             TIMEOUT_SECONDS: 1200
             # Memory limits
-            # Version 3 of docker does not easily allow to set ulimits 
+            # Version 3 of docker does not easily allow to set ulimits
             # any more. But we also want to set limits regarding the real
-            # available memory, therefore only a percentage of can be set. 
-            # It is still possible to set a fixed absolute limit though. 
+            # available memory, therefore only a percentage of can be set.
+            # It is still possible to set a fixed absolute limit though.
             # The smaller result value will be set.
-            # 
+            #
             # Sometimes a job (e.g. latexml) may start to use huge amounts
             # of memory. Here you can limit the amount, so the docker host
             # does not become unresponsive.
             # The percentage of available memory a worker may use.
-            # If you use several workers on the same host, you might 
+            # If you use several workers on the same host, you might
             # want to decrease this value.
             MEMLIMIT_PERCENT: 50
             #MEMLIMIT_ABSOLUTE: 8G

--- a/docker/LaTeXML-Dockerfile
+++ b/docker/LaTeXML-Dockerfile
@@ -1,83 +1,13 @@
+FROM texmlbus_latexml_git as latexml
 
-# /=====================================================================\ #
-# | LaTeXML Dockerfile                                                  | #
-# | A Dockerfile to create a Docker Image with LaTeXML preinstalled.    | #
-# |=====================================================================| #
-# | Thanks to Tom Wiesing <tom.wiesing@gmail.com>                       | #
-# | Part of LaTeXML:                                                    | #
-# |  Public domain software, produced as part of work done by the       | #
-# |  United States Government & not subject to copyright in the US.     | #
-# |---------------------------------------------------------------------| #
-# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
-# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
-# \=========================================================ooo==U==ooo=/ #
-
-# This Dockerfile expects the root directory of LaTeXML as a build context. 
-# To achieve this run the following command from the root directory:
-#
-# > docker build -t latexml -f release/docker/Dockerfile .
-
-# This Dockerfile can include a full TeXLive installation. 
-# This is enabled by default however it can be disabled by providing a
-# build argument like so:
-#
-# > docker build -t latexml --build-arg WITH_TEXLIVE=no -f release/docker/Dockerfile .
-#
-# Please be aware that including a full TeXLive installation can take a
-# significant amount of time (depending on network connection) and will
-# increase the image size to several Gigabytes. 
-#
-# Futhermore to speed up the build process, it is also possible to
-# tell docker not to run the tests during the build proess. To achieve
-# this, pass --build-arg WITH_TESTS=no to the docker build command, e.g:
-#
-# > docker build -t latexml --build-arg WITH_TESTS=no -f release/docker/Dockerfile .
-
-
-# We start from alpine linux 3.11
-FROM alpine:3.12 as latexml_base
-
-RUN echo -e \
-" ############################################################\n" \
-"If the next command fails, you have not checked out LaTeXML.\n" \
-"Please enter: git submodule update --init --recursive\n" \
-"############################################################\n"
-COPY bin/latexml /dev/null
-
-# Install the dependencies
-RUN apk add --no-cache \
-    db-dev \
-    gcc \
-    libc-dev \
-    libgcrypt \
-    libgcrypt-dev \
-    libxml2 \
-    libxml2-dev \
-    libxslt \
-    libxslt-dev \
-    make \
-    perl \
-    perl-dev \
-    perl-utils \
-    wget \
-    zlib \
-    zlib-dev
-
-# Configure TeXLive Support
-# Set to "no" to disable, "yes" to enable
-ARG WITH_TEXLIVE="no"
+# This is an extract of the original Dockerfile in LaTeXML/relase/docker/Dockerfile.
+# The first part has been put into texmlbus_latexml_base, while the second part is found here.
+# By splitting the content into several files, changes can be applied without complete reinstallation of TeX.
 
 # Configure if we test during the build
 ARG WITH_TESTS="no"
 
-# Install TeXLive if not disabled
-RUN [ "$WITH_TEXLIVE" == "no" ] || (\
-           apk add --no-cache -U poppler harfbuzz-icu zziplib texlive-full \
-        && ln -s /usr/bin/mktexlsr /usr/bin/mktexlsr.pl \
-    )
-
-# Install cpanminus
-RUN apk add --no-cache -U perl-app-cpanminus
+# Install the dependencies
 
 # Make a directory for latexml
 RUN mkdir -p /opt/latexml
@@ -85,7 +15,7 @@ RUN mkdir -p /opt/latexml
 # Add all of the source files
 ADD bin/            /opt/latexml/bin
 #ADD doc/            /opt/latexml/doc/
-ADD lib/            /opt/latexml/lib 
+ADD lib/            /opt/latexml/lib
 #ADD release/        /opt/latexml/release/
 ADD t/              /opt/latexml/t/
 ADD tools/          /opt/latexml/tools/
@@ -103,3 +33,4 @@ ADD Makefile.PL     /opt/latexml/Makefile.PL
 WORKDIR /opt/latexml
 
 RUN if [ "$WITH_TESTS" == "no" ] ; then cpanm --notest . ; else cpanm . ; fi
+

--- a/docker/LaTeXML-Dockerfile_edge
+++ b/docker/LaTeXML-Dockerfile_edge
@@ -1,105 +1,36 @@
+FROM texmlbus_latexml_git_edge as latexml_edge
 
-# /=====================================================================\ #
-# | LaTeXML Dockerfile                                                  | #
-# | A Dockerfile to create a Docker Image with LaTeXML preinstalled.    | #
-# |=====================================================================| #
-# | Thanks to Tom Wiesing <tom.wiesing@gmail.com>                       | #
-# | Part of LaTeXML:                                                    | #
-# |  Public domain software, produced as part of work done by the       | #
-# |  United States Government & not subject to copyright in the US.     | #
-# |---------------------------------------------------------------------| #
-# | Bruce Miller <bruce.miller@nist.gov>                        #_#     | #
-# | http://dlmf.nist.gov/LaTeXML/                              (o o)    | #
-# \=========================================================ooo==U==ooo=/ #
-
-# This Dockerfile expects the root directory of LaTeXML as a build context.
-# To achieve this run the following command from the root directory:
-#
-# > docker build -t latexml -f release/docker/Dockerfile .
-
-# This Dockerfile can include a full TeXLive installation.
-# This is enabled by default however it can be disabled by providing a
-# build argument like so:
-#
-# > docker build -t latexml --build-arg WITH_TEXLIVE=no -f release/docker/Dockerfile .
-#
-# Please be aware that including a full TeXLive installation can take a
-# significant amount of time (depending on network connection) and will
-# increase the image size to several Gigabytes.
-#
-# Futhermore to speed up the build process, it is also possible to
-# tell docker not to run the tests during the build proess. To achieve
-# this, pass --build-arg WITH_TESTS=no to the docker build command, e.g:
-#
-# > docker build -t latexml --build-arg WITH_TESTS=no -f release/docker/Dockerfile .
-
-
-# We start from alpine linux edge
-FROM alpine:edge as latexml_base_edge
-
-RUN echo -e \
-" ############################################################################\n" \
-"If the next command fails, you have not checked out LaTeXML as LaTeXML_edge.\n" \
-"Please enter: git submodule add -b master https://github.com/brucemiller/LaTeXML.git src/LaTeXML_edge\n" \
-"############################################################################\n"
-COPY bin/latexml /dev/null
-
-# Install the dependencies
-RUN apk add --no-cache \
-    db-dev \
-    gcc \
-    libc-dev \
-    libgcrypt \
-    libgcrypt-dev \
-    libxml2 \
-    libxml2-dev \
-    libxslt \
-    libxslt-dev \
-    make \
-    perl \
-    perl-dev \
-    perl-utils \
-    wget \
-    zlib \
-    zlib-dev
-
-# Configure TeXLive Support
-# Set to "no" to disable, "yes" to enable
-ARG WITH_TEXLIVE="no"
+# This is an extract of the original Dockerfile in LaTeXML/relase/docker/Dockerfile.
+# The first part has been put into texmlbus_latexml_base, while the second part is found here.
+# By splitting the content into several files, changes can be applied without complete reinstallation of TeX.
 
 # Configure if we test during the build
 ARG WITH_TESTS="no"
 
-# Install TeXLive if not disabled
-RUN [ "$WITH_TEXLIVE" == "no" ] || (\
-           apk add --no-cache -U poppler harfbuzz-icu zziplib texlive-full \
-        && ln -s /usr/bin/mktexlsr /usr/bin/mktexlsr.pl \
-    )
-
-# Install cpanminus
-RUN apk add --no-cache -U perl-app-cpanminus
+# Install the dependencies
 
 # Make a directory for latexml
-RUN mkdir -p /opt_edge/latexml
+RUN mkdir -p /opt/latexml
 
 # Add all of the source files
-ADD bin/            /opt_edge/latexml/bin
+ADD bin/            /opt/latexml/bin
 #ADD doc/            /opt/latexml/doc/
-ADD lib/            /opt_edge/latexml/lib
+ADD lib/            /opt/latexml/lib
 #ADD release/        /opt/latexml/release/
-ADD t/              /opt_edge/latexml/t/
-ADD tools/          /opt_edge/latexml/tools/
+ADD t/              /opt/latexml/t/
+ADD tools/          /opt/latexml/tools/
 #ADD Changes         /opt/latexml/Changes
 #ADD INSTALL         /opt/latexml/INSTALL
 #ADD INSTALL.SKIP    /opt/latexml/INSTALL.SKIP
-ADD LICENSE         /opt_edge/latexml/LICENSE
-ADD Makefile.PL     /opt_edge/latexml/Makefile.PL
+ADD LICENSE         /opt/latexml/LICENSE
+ADD Makefile.PL     /opt/latexml/Makefile.PL
 #ADD MANIFEST        /opt/latexml/MANIFEST
 #ADD MANIFEST.SKIP   /opt/latexml/MANIFEST.SKIP
 #ADD manual.pdf      /opt/latexml/manual.pdf
 #ADD README.pod      /opt/README.pod
 
 # Installing  via cpanm (with or without tests)
-WORKDIR /opt_edge/latexml
+WORKDIR /opt/latexml
 
 RUN if [ "$WITH_TESTS" == "no" ] ; then cpanm --notest . ; else cpanm . ; fi
+

--- a/docker/latexml_base/Dockerfile
+++ b/docker/latexml_base/Dockerfile
@@ -1,0 +1,98 @@
+# This image is used as base image for LaTeXML.
+# It installs ghostscript, imagemagick and
+# the webserver and php to be run as worker.
+FROM alpine:3.12 as latexml_base
+
+ARG TIMEOUT_SECONDS="1200"
+
+RUN echo -e \
+" ############################################################\n" \
+"If the next command fails, you have not checked out LaTeXML.\n" \
+"Please enter: git submodule update --init --recursive\n" \
+"############################################################\n"
+COPY LaTeXML/bin/latexml /dev/null
+
+RUN apk add --no-cache \
+    db-dev \
+    gcc \
+    libc-dev \
+    libgcrypt \
+    libgcrypt-dev \
+    libxml2 \
+    libxml2-dev \
+    libxslt \
+    libxslt-dev \
+    make \
+    perl \
+    perl-dev \
+    perl-utils \
+    wget \
+    zlib \
+    zlib-dev
+
+# Configure TeXLive Support
+# Set to "no" to disable, "yes" to enable
+ARG WITH_TEXLIVE="yes"
+
+# Install TeXLive if not disabled
+RUN [ "$WITH_TEXLIVE" == "no" ] || (\
+           apk add --no-cache -U poppler harfbuzz-icu zziplib texlive-full \
+        && ln -s /usr/bin/mktexlsr /usr/bin/mktexlsr.pl \
+    )
+
+# Install cpanminus
+RUN apk add --no-cache -U perl-app-cpanminus
+
+
+
+# Install the dependencies
+RUN apk add --no-cache \
+    ghostscript \
+    git \
+    imagemagick \
+    imagemagick-perlmagick
+
+# Install packages fotr worker: apache2, php, make
+RUN apk add \
+    apache2 \
+    apache2-proxy \
+    make \
+    openrc \
+    php-cli \
+    php-fpm \
+    php-json \
+    php-pcntl \
+    php-posix \
+    php-sysvshm
+
+# configure apache
+RUN sed -i "s#/var/www/localhost/htdocs#/srv/texmlbus/src/worker/htdocs#" /etc/apache2/httpd.conf \
+    && sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf \
+    && sed -i "s#^Timeout.*#Timeout ${TIMEOUT_SECONDS}#" /etc/apache2/conf.d/default.conf \
+    && printf "\n<Directory \"/srv/texmlbus/src/worker/htdocs\">\nAllowOverride All\nAddDefaultCharset utf-8\n<FilesMatch \"\\.php\$\">\nSetHandler \"proxy:unix:/run/php-fpm.sock|fcgi://localhost\"\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "</FilesMatch>\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "</Directory>\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "# Never use 'enablereuse=on' with unix domain sockets.\n"  >> /etc/apache2/conf.d/default.conf \
+    && printf "# php-fpm will get stuck with processes in finishing state.\n" >> /etc/apache2/conf.d/default.conf\
+    && printf "<Proxy \"fcgi://localhost/\" flushpackets=on max=10>\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "</Proxy>\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "# Enable 'status' and 'ping' page\n"  >> /etc/apache2/conf.d/default.conf \
+    && printf "<LocationMatch \"/(ping|status)\">\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "SetHandler \"proxy:unix:/run/php-fpm.sock|fcgi://localhost\"\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "</LocationMatch>\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "# Enable *real-time* 'status' page\n"  >> /etc/apache2/conf.d/default.conf \
+    && printf "#<IfModule alias_module>\n"  >> /etc/apache2/conf.d/default.conf \
+    && printf "#Alias /realtime-status \"/var/lib/php7/fpm/status.html\"\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "#</IfModule>\n" >> /etc/apache2/conf.d/default.conf
+
+
+# configure php-fpm
+RUN sed -i "s#^user\s*=\s*nobody#user = dmake#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#group\s*=\s*nobody#user = dmake#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#^listen\s*=.*#listen = /run/php-fpm.sock#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#^;listen.owner\s*=.*#listen.owner = dmake#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#^;listen.group\s*=.*#listen.group = dmake#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#^;listen.mode\s*=.*#listen.mode = 0666#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#^pm.max_children\s*=.*#pm.max_children = 15#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#;catch_workers_output.*#catch_workers_output = yes#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i 's#;pm.status_path#pm.status_path#' /etc/php7/php-fpm.d/www.conf

--- a/docker/latexml_base_edge/Dockerfile
+++ b/docker/latexml_base_edge/Dockerfile
@@ -1,0 +1,104 @@
+# This image is used as base image for LaTeXML.
+# It installs ghostscript, imagemagick and
+# the webserver and php to be run as worker.
+FROM alpine:edge as latexml_base_edge
+
+ARG TIMEOUT_SECONDS="1200"
+
+RUN echo -e \
+" ############################################################\n" \
+"If the next command fails, you have not checked out LaTeXML_edge.\n" \
+"Please enter: cd docker; git clone https://github.com/brucemiller/LaTeXML.git LaTeXML_edge\n" \
+"############################################################\n"
+COPY LaTeXML_edge/bin/latexml /dev/null
+
+## base latexml start
+
+RUN apk add --no-cache \
+    db-dev \
+    gcc \
+    libc-dev \
+    libgcrypt \
+    libgcrypt-dev \
+    libxml2 \
+    libxml2-dev \
+    libxslt \
+    libxslt-dev \
+    make \
+    perl \
+    perl-dev \
+    perl-utils \
+    wget \
+    zlib \
+    zlib-dev
+
+# Configure TeXLive Support
+# Set to "no" to disable, "yes" to enable
+ARG WITH_TEXLIVE="yes"
+
+# Install TeXLive if not disabled
+RUN [ "$WITH_TEXLIVE" == "no" ] || (\
+           apk add --no-cache -U poppler harfbuzz-icu zziplib texlive-full \
+        && ln -s /usr/bin/mktexlsr /usr/bin/mktexlsr.pl \
+    )
+
+# Install cpanminus
+RUN apk add --no-cache -U perl-app-cpanminus
+
+## base latexml end
+
+# For some reason pdftex.map is not created (?)
+RUN echo 'y' | /usr/bin/updmap-sys --syncwithtrees \
+    && /usr/bin/updmap-sys
+
+# Install further dependencies
+RUN apk add --no-cache \
+    ghostscript \
+    git \
+    imagemagick \
+    imagemagick-perlmagick
+
+# Install packages fotr worker: apache2, php, make
+RUN apk add \
+    apache2 \
+    apache2-proxy \
+    make \
+    openrc \
+    php-cli \
+    php-fpm \
+    php-json \
+    php-pcntl \
+    php-posix \
+    php-sysvshm
+
+# configure apache
+RUN sed -i "s#/var/www/localhost/htdocs#/srv/texmlbus/src/worker/htdocs#" /etc/apache2/httpd.conf \
+    && sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf \
+    && sed -i "s#^Timeout.*#Timeout ${TIMEOUT_SECONDS}#" /etc/apache2/conf.d/default.conf \
+    && printf "\n<Directory \"/srv/texmlbus/src/worker/htdocs\">\nAllowOverride All\nAddDefaultCharset utf-8\n<FilesMatch \"\\.php\$\">\nSetHandler \"proxy:unix:/run/php-fpm.sock|fcgi://localhost\"\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "</FilesMatch>\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "</Directory>\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "# Never use 'enablereuse=on' with unix domain sockets.\n"  >> /etc/apache2/conf.d/default.conf \
+    && printf "# php-fpm will get stuck with processes in finishing state.\n" >> /etc/apache2/conf.d/default.conf\
+    && printf "<Proxy \"fcgi://localhost/\" flushpackets=on max=10>\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "</Proxy>\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "# Enable 'status' and 'ping' page\n"  >> /etc/apache2/conf.d/default.conf \
+    && printf "<LocationMatch \"/(ping|status)\">\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "SetHandler \"proxy:unix:/run/php-fpm.sock|fcgi://localhost\"\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "</LocationMatch>\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "# Enable *real-time* 'status' page\n"  >> /etc/apache2/conf.d/default.conf \
+    && printf "#<IfModule alias_module>\n"  >> /etc/apache2/conf.d/default.conf \
+    && printf "#Alias /realtime-status \"/var/lib/php7/fpm/status.html\"\n" >> /etc/apache2/conf.d/default.conf \
+    && printf "#</IfModule>\n" >> /etc/apache2/conf.d/default.conf
+
+
+# configure php-fpm
+RUN sed -i "s#^user\s*=\s*nobody#user = dmake#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#group\s*=\s*nobody#user = dmake#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#^listen\s*=.*#listen = /run/php-fpm.sock#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#^;listen.owner\s*=.*#listen.owner = dmake#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#^;listen.group\s*=.*#listen.group = dmake#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#^;listen.mode\s*=.*#listen.mode = 0666#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#^pm.max_children\s*=.*#pm.max_children = 15#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i "s#;catch_workers_output.*#catch_workers_output = yes#" /etc/php7/php-fpm.d/www.conf \
+    && sed -i 's#;pm.status_path#pm.status_path#' /etc/php7/php-fpm.d/www.conf

--- a/docker/latexml_dmake/Dockerfile
+++ b/docker/latexml_dmake/Dockerfile
@@ -1,23 +1,10 @@
-#FROM latexml_base AS latexml_dmake
-# PUBLIC DOMAIN Bruce Miller https://github.com/brucemiller/LaTeXML.git
+# This image is created after latexml has been built.
+# Package installation has been moved to latexml_base.
 FROM texmlbus_latexml AS latexml_dmake
 
-ARG TIMEOUT_SECONDS
-
-RUN apk add \
-    apache2 \
-    apache2-proxy \
-    imagemagick \
-    imagemagick-perlmagick \
-    ghostscript \
-    make \
-    openrc \
-    php-cli \
-    php-fpm \
-    php-json \
-    php-pcntl \
-    php-posix \
-    php-sysvshm
+# necessary modules should already have been installed
+# in texmlbus_latexml_base, so it it is not necessary to reinstall
+# them after latexml has changed
 
 RUN addgroup dmake \
     && adduser -D -g "" -h "/home/dmake" -G dmake dmake \
@@ -37,39 +24,6 @@ RUN ln -s /usr/local/bin/latexmlpost /bin/latexmlpost
 # use latexpand
 # BSD Matthieu Moy https://gitlab.com/latexpand/latexpand
 COPY apps/latexpand/latexpand /usr/bin
-
-ENV TIMEOUT_SECONDS=$TIMEOUT_SECONDS
-# configure apache
-RUN sed -i "s#/var/www/localhost/htdocs#/srv/texmlbus/src/worker/htdocs#" /etc/apache2/httpd.conf \
-    && sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf \
-    && sed -i "s#^Timeout.*#Timeout ${TIMEOUT_SECONDS}#" /etc/apache2/conf.d/default.conf \
-    && printf "\n<Directory \"/srv/texmlbus/src/worker/htdocs\">\nAllowOverride All\nAddDefaultCharset utf-8\n<FilesMatch \"\\.php\$\">\nSetHandler \"proxy:unix:/run/php-fpm.sock|fcgi://localhost\"\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "</FilesMatch>\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "</Directory>\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "# Never use 'enablereuse=on' with unix domain sockets.\n"  >> /etc/apache2/conf.d/default.conf \
-    && printf "# php-fpm will get stuck with processes in finishing state.\n" >> /etc/apache2/conf.d/default.conf\
-    && printf "<Proxy \"fcgi://localhost/\" flushpackets=on max=10>\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "</Proxy>\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "# Enable 'status' and 'ping' page\n"  >> /etc/apache2/conf.d/default.conf \
-    && printf "<LocationMatch \"/(ping|status)\">\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "SetHandler \"proxy:unix:/run/php-fpm.sock|fcgi://localhost\"\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "</LocationMatch>\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "# Enable *real-time* 'status' page\n"  >> /etc/apache2/conf.d/default.conf \
-    && printf "#<IfModule alias_module>\n"  >> /etc/apache2/conf.d/default.conf \
-    && printf "#Alias /realtime-status \"/var/lib/php7/fpm/status.html\"\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "#</IfModule>\n" >> /etc/apache2/conf.d/default.conf
-
-
-# configure php-fpm
-RUN sed -i "s#^user\s*=\s*nobody#user = dmake#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#group\s*=\s*nobody#user = dmake#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#^listen\s*=.*#listen = /run/php-fpm.sock#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#^;listen.owner\s*=.*#listen.owner = dmake#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#^;listen.group\s*=.*#listen.group = dmake#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#^;listen.mode\s*=.*#listen.mode = 0666#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#^pm.max_children\s*=.*#pm.max_children = 15#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#;catch_workers_output.*#catch_workers_output = yes#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i 's#;pm.status_path#pm.status_path#' /etc/php7/php-fpm.d/www.conf
 
 RUN mkdir /bootstrap
 ADD start.sh /bootstrap/

--- a/docker/latexml_dmake_edge/Dockerfile
+++ b/docker/latexml_dmake_edge/Dockerfile
@@ -1,23 +1,10 @@
-#FROM latexml_base AS latexml_dmake
-# PUBLIC DOMAIN Bruce Miller https://github.com/brucemiller/LaTeXML.git
+# This image is created after latexml has been built.
+# Package installation has been moved to latexml_base_edge.
 FROM texmlbus_latexml_edge AS latexml_dmake_edge
 
-ARG TIMEOUT_SECONDS
-
-RUN apk add \
-    apache2 \
-    apache2-proxy \
-    imagemagick \
-    imagemagick-perlmagick \
-    ghostscript \
-    make \
-    openrc \
-    php-cli \
-    php-fpm \
-    php-json \
-    php-pcntl \
-    php-posix \
-    php-sysvshm
+# necessary modules should already have been installed
+# in texmlbus_latexml_base_edge, so it it is not necessary to reinstall
+# them after latexml has changed
 
 RUN addgroup dmake \
     && adduser -D -g "" -h "/home/dmake" -G dmake dmake \
@@ -37,39 +24,6 @@ RUN ln -s /usr/local/bin/latexmlpost /bin/latexmlpost
 # use latexpand
 # BSD Matthieu Moy https://gitlab.com/latexpand/latexpand
 COPY apps/latexpand/latexpand /usr/bin
-
-ENV TIMEOUT_SECONDS=$TIMEOUT_SECONDS
-# configure apache
-RUN sed -i "s#/var/www/localhost/htdocs#/srv/texmlbus/src/worker/htdocs#" /etc/apache2/httpd.conf \
-    && sed -i '/LoadModule rewrite_module/s/^#//g' /etc/apache2/httpd.conf \
-    && sed -i "s#^Timeout.*#Timeout ${TIMEOUT_SECONDS}#" /etc/apache2/conf.d/default.conf \
-    && printf "\n<Directory \"/srv/texmlbus/src/worker/htdocs\">\nAllowOverride All\nAddDefaultCharset utf-8\n<FilesMatch \"\\.php\$\">\nSetHandler \"proxy:unix:/run/php-fpm.sock|fcgi://localhost\"\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "</FilesMatch>\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "</Directory>\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "# Never use 'enablereuse=on' with unix domain sockets.\n"  >> /etc/apache2/conf.d/default.conf \
-    && printf "# php-fpm will get stuck with processes in finishing state.\n" >> /etc/apache2/conf.d/default.conf\
-    && printf "<Proxy \"fcgi://localhost/\" flushpackets=on max=10>\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "</Proxy>\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "# Enable 'status' and 'ping' page\n"  >> /etc/apache2/conf.d/default.conf \
-    && printf "<LocationMatch \"/(ping|status)\">\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "SetHandler \"proxy:unix:/run/php-fpm.sock|fcgi://localhost\"\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "</LocationMatch>\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "# Enable *real-time* 'status' page\n"  >> /etc/apache2/conf.d/default.conf \
-    && printf "#<IfModule alias_module>\n"  >> /etc/apache2/conf.d/default.conf \
-    && printf "#Alias /realtime-status \"/var/lib/php7/fpm/status.html\"\n" >> /etc/apache2/conf.d/default.conf \
-    && printf "#</IfModule>\n" >> /etc/apache2/conf.d/default.conf
-
-
-# configure php-fpm
-RUN sed -i "s#^user\s*=\s*nobody#user = dmake#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#group\s*=\s*nobody#user = dmake#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#^listen\s*=.*#listen = /run/php-fpm.sock#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#^;listen.owner\s*=.*#listen.owner = dmake#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#^;listen.group\s*=.*#listen.group = dmake#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#^;listen.mode\s*=.*#listen.mode = 0666#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#^pm.max_children\s*=.*#pm.max_children = 15#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i "s#;catch_workers_output.*#catch_workers_output = yes#" /etc/php7/php-fpm.d/www.conf \
-    && sed -i 's#;pm.status_path#pm.status_path#' /etc/php7/php-fpm.d/www.conf
 
 RUN mkdir /bootstrap
 ADD start.sh /bootstrap/

--- a/docker/latexml_git/Dockerfile
+++ b/docker/latexml_git/Dockerfile
@@ -1,0 +1,12 @@
+FROM texmlbus_latexml_base as latexml_git
+
+# Make a directory for latexml
+RUN mkdir -p /opt/latexml
+
+# to have revision info for compile, .git must be available
+ADD .git/modules/src/LaTeXML/ /opt/latexml/.git
+
+# latexml is installed as module, fix path
+RUN sed -i '/worktree/d' /opt/latexml/.git/config
+
+

--- a/docker/latexml_git_edge/Dockerfile
+++ b/docker/latexml_git_edge/Dockerfile
@@ -1,0 +1,18 @@
+FROM texmlbus_latexml_base_edge as latexml_git_edge
+
+# Make a directory for latexml
+RUN mkdir -p /opt/latexml
+
+##
+## LaTeXML_edge is added as normal repository, not as submodule. 
+## Therefore copy from that directory.
+# to have revision info for compile, .git must be available
+#ADD .git/modules/src/LaTeXML_edge/ /opt/latexml/.git
+
+# latexml is installed as module, fix path
+#RUN sed -i '/worktree/d' /opt/latexml/.git/config
+
+ADD docker/LaTeXML_edge/.git /opt/latexml/.git
+
+
+

--- a/texmlbus-edge.yml
+++ b/texmlbus-edge.yml
@@ -1,15 +1,53 @@
 # docker-compose.yml
 version: '3.4'
 services:
+    latexml_base_edge:
+        build:
+            # needs access to LaTeXML as well
+            context: docker
+            dockerfile: latexml_base_edge/Dockerfile
+            target: latexml_base_edge
+            args:
+                # Sometimes a job (e.g. latexml) may run endlessly, limit
+                # the amount of time a job can run.
+                TIMEOUT_SECONDS: 1200
+
+        # actually just image is needed, not the container
+        # will soon use profile: never
+        command: 'echo "Ok, that this container exits."'
+
+    latexml_git_edge:
+        build:
+            # needs access to modules
+            context: .
+            dockerfile: docker/latexml_git_edge/Dockerfile
+            target: latexml_git_edge
+        depends_on: 
+            - latexml_base_edge
+
+        # actually just image is needed, not the container
+        # will soon use profile: never
+        command: 'echo "OK, that this container exits."'
+        
+        # as it is not a submodule, directory already exists
+        #volumes:
+             #- ./.git/modules/src/LaTeXML:/.git
+
+
     latexml_edge:
         build:
             context: docker/LaTeXML_edge
             dockerfile: ../LaTeXML-Dockerfile_edge
             #dockerfile: release/docker/Dockerfile
-            target: latexml_base_edge
+            target: latexml_edge
             args:
                 - WITH_TEXLIVE=yes
                 - WITH_TESTS=no
+        depends_on: 
+            - latexml_git_edge
+
+        # actually just image is needed, not the container
+        # will soon use profile: never
         command: 'echo "OK, that this container exits."'
 
     latexml_dmake_edge:
@@ -17,10 +55,8 @@ services:
             context: docker/latexml_dmake_edge
             dockerfile: Dockerfile
             target: latexml_dmake_edge
-            args:
-                # Sometimes a job (e.g. latexml) may run endlessly, limit
-                # the amount of time a job can run.
-                TIMEOUT_SECONDS: 1200
+        depends_on:
+            - latexml_edge
 
         environment:
             DOCKERIZED: 1

--- a/volume/src/server/include/UtilMisc.php
+++ b/volume/src/server/include/UtilMisc.php
@@ -90,7 +90,7 @@ class UtilMisc
             if (isset($arr[3])) {
                 $retArr[] = $hostGroupName
                             . ': ' . $arr[3]
-                            . ';'
+                            . ' '
                             . ($arr[4] ?? '')
                             . ' '
                             . ($arr[5] ?? '');


### PR DESCRIPTION
- to show revision info, container needs .git information
- _git container add .git information before latexml is being installed
- split original latexml Dockerfile, so updates can be applied without
  need to reinstall other packages
- update works with image rebuild and also inside container
- LaTeXML_edge is considered no to be submodule.
- add dependency to different latexml containers to avoid image building problems.