### PR TITLE
Handle docker compose v2

### DIFF
--- a/build-images.bat
+++ b/build-images.bat
@@ -1,0 +1,8 @@
+docker pull alpine:3.12
+docker pull alpine:3.13
+docker compose build latexml_base
+docker compose build latexml_git
+docker compose build latexml
+docker compose build latexml_dmake
+docker compose up
+

--- a/build-images.bat
+++ b/build-images.bat
@@ -1,3 +1,5 @@
+:: Use this script on windows, if you are
+:: using docker compose v2 and images do not build
 docker pull alpine:3.12
 docker pull alpine:3.13
 docker compose build latexml_base

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,0 +1,10 @@
+# Use this script, if you are using docker compose v2
+# and the images do not build.
+docker pull alpine:3.12
+docker pull alpine:3.13
+docker compose build latexml_base
+docker compose build latexml_git
+docker compose build latexml
+docker compose build latexml_dmake
+docker compose up
+


### PR DESCRIPTION
Add two scripts that linearize image build, as docker compose v2 fails to build images, as it tries to build everything in parallel.